### PR TITLE
Switch to C99 printf macros

### DIFF
--- a/c/gen_test.c
+++ b/c/gen_test.c
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-
+#include <inttypes.h>
 
 const unsigned char hex_table[] = "0123456789abcdef";
 
@@ -76,12 +76,12 @@ void gen_o_dump(const gen_o o) {
 
 	printf("{ ");
 	if (o.b) printf("b=true ");
-	if (o.u8) printf("u8=%zd ", o.u8);
-	if (o.u16) printf("u16=%zd ", o.u16);
-	if (o.u32) printf("u32=%zd ", o.u32);
-	if (o.i64) printf("i64=%zd ", o.i64);
-	if (o.i32) printf("i32=%zd ", o.i32);
-	if (o.i64) printf("i64=%zd ", o.i64);
+        if (o.u8) printf("u8=%" PRIu8 " ", o.u8);
+        if (o.u16) printf("u16=%" PRIu16 " ", o.u16);
+        if (o.u32) printf("u32=%" PRIu32 " ", o.u32);
+        if (o.i64) printf("i64=%" PRId64 " ", o.i64);
+        if (o.i32) printf("i32=%" PRId32 " ", o.i32);
+        if (o.i64) printf("i64=%" PRId64 " ", o.i64);
 	if (o.f32) printf("f32=%f ", o.f32);
 	if (o.f32s.len) {
 		printf("f32s=[");


### PR DESCRIPTION
Switch to C99 printf macros defined in inttypes.h (i.e. PRIu8, PRIu16, PRIu32, PRId32, PRId64) to avoid compilation warning with gcc.