### PR TITLE
fix: uint16 marshalling for javascript

### DIFF
--- a/template/ecma-marshal.txt
+++ b/template/ecma-marshal.txt
@@ -26,7 +26,7 @@
 				buf[i++] = this.{{.NameNative}};
 			} else {
 				buf[i++] = {{.Index}};
-				buf[i++] = this.{{.NameNative}} >>> 0;
+				buf[i++] = (this.{{.NameNative}} >>> 8) & 255;
 				buf[i++] = this.{{.NameNative}} & 255;
 			}
 		}


### PR DESCRIPTION
fix: the ecma-marshal.txt template had an error for uint16 marshalling. This version replaces the >>> 0 shift with a whole byte shift >>> 8